### PR TITLE
Fix Command Injection vulnerability

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -84,7 +84,7 @@ function * initFeature(context, heroku, callback) {
     } else if (!(_hasExecBuildpack(buildpacks, buildpackUrls))) {
       yield _enableFeature(context, heroku)
       cli.log(`Adding the Heroku Exec buildpack to ${context.app}`)
-      child.execSync(`heroku buildpacks:add -i 1 heroku/exec -a ${context.app}`)
+      child.execFileSync('heroku', ['buildpacks:add', '-i', '1', 'heroku/exec', '-a', context.app])
       cli.log('')
       cli.log('Run the following commands to redeploy your app, then Heroku Exec will be ready to use:')
       cli.log(cli.color.magenta('  git commit -m "Heroku Exec initialization" --allow-empty'))

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -84,7 +84,7 @@ function * initFeature(context, heroku, callback) {
     } else if (!(_hasExecBuildpack(buildpacks, buildpackUrls))) {
       yield _enableFeature(context, heroku)
       cli.log(`Adding the Heroku Exec buildpack to ${context.app}`)
-      child.execFileSync(`heroku`, [`buildpacks:add`, `-i`, `1`, `heroku/exec`, `-a`, `${context.app}`])
+      child.execSync(`heroku buildpacks:add -i 1 heroku/exec -a ${context.app}`)
       cli.log('')
       cli.log('Run the following commands to redeploy your app, then Heroku Exec will be ready to use:')
       cli.log(cli.color.magenta('  git commit -m "Heroku Exec initialization" --allow-empty'))

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -105,9 +105,11 @@ function ssh(context, addonHost, dynoUser, privateKey, proxyKey) {
                 }
 
                 try {
-                  sshCommand = sshCommand.match(/('(\\'|[^'])*'|"(\\"|[^"])*"|\/(\\\/|[^\/])*\/|(\\ |[^ ])+|[\w-]+)/g)
-                  child.execFileSync(sshCommand[0], sshCommand.slice(1), { stdio: ['inherit', 'inherit', 'ignore' ] }
-                  )
+                  // Prevent ReDoS
+                  if(sshCommand.length < 1000) {
+                    sshCommand = sshCommand.match(/('(\\'|[^'])*'|"(\\"|[^"])*"|\/(\\\/|[^\/])*\/|(\\ |[^ ])+|[\w-]+)/g)
+                    child.execFileSync(sshCommand[0], sshCommand.slice(1), { stdio: ['inherit', 'inherit', 'ignore' ] })
+                  }
                 } catch (e) {
                   if (e.stderr) cli.hush(e.stderr)
                   cli.hush(`[cli-ssh] exit: ${e.status}, ${e.message}`)

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -105,7 +105,8 @@ function ssh(context, addonHost, dynoUser, privateKey, proxyKey) {
                 }
 
                 try {
-                  child.execSync(sshCommand, { stdio: ['inherit', 'inherit', 'ignore' ] }
+                  sshCommand = sshCommand.match(/('(\\'|[^'])*'|"(\\"|[^"])*"|\/(\\\/|[^\/])*\/|(\\ |[^ ])+|[\w-]+)/g)
+                  child.execFileSync(sshCommand[0], sshCommand.slice(1), { stdio: ['inherit', 'inherit', 'ignore' ] }
                   )
                 } catch (e) {
                   if (e.stderr) cli.hush(e.stderr)

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -105,8 +105,7 @@ function ssh(context, addonHost, dynoUser, privateKey, proxyKey) {
                 }
 
                 try {
-                  sshCommand = sshCommand.split(' ')
-                  child.execFileSync(sshCommand[0],sshCommand.slice(1), { stdio: ['inherit', 'inherit', 'ignore' ] }
+                  child.execSync(sshCommand, { stdio: ['inherit', 'inherit', 'ignore' ] }
                   )
                 } catch (e) {
                   if (e.stderr) cli.hush(e.stderr)


### PR DESCRIPTION
### 📊 Metadata *

This vulnerability was previously reported [here](https://github.com/418sec/heroku-exec-util/pull/1), but the solution provided was not enough and the maintainer reverted it because of this [issue](https://github.com/heroku/heroku-exec-util/pull/22).

#### Bounty URL: https://www.huntr.dev/bounties/2-npm-heroku-exec-util

### ⚙️ Description *

The `heroku-exec-util` package is vulnerable to `Command Injection` via argument concatenation. It allows attackers to execute arbitrary OS commands.

### 💻 Technical Description *

The fix replaces the `execSync` with `execFileSync`, which defines the binary `ssh` and isolates the arguments.

The array of arguments is based on a regex, which solves the issue reported previously about spaces into single or double quotes.

### 🐛 Proof of Concept (PoC) *

```javascript
// poc.js

const  heroku = require('heroku-exec-util');
heroku.ssh({args:{}},'$(touch poc.txt)','','test',{path:'test'});
```

The execution of the code above implies the creation of `poc.txt` file.

### 🔥 Proof of Fix (PoF) *

The execution of the PoC does not imply the creation of `poc.txt` file.

Regex test:
```javascript
//Double quotes
let sshCommand = `ssh arg1 arg2 "a b c" arg4`;
let output = sshCommand.match(/('(\\'|[^'])*'|"(\\"|[^"])*"|\/(\\\/|[^\/])*\/|(\\ |[^ ])+|[\w-]+)/g);
console.log(output); // [ 'ssh', 'arg1', 'arg2', '"a b c"', 'arg4' ]

//Single quotes
sshCommand = `ssh arg1 arg2 'a b c' arg4`;
output = sshCommand.match(/('(\\'|[^'])*'|"(\\"|[^"])*"|\/(\\\/|[^\/])*\/|(\\ |[^ ])+|[\w-]+)/g);
console.log(output); // [ 'ssh', 'arg1', 'arg2', "'a b c'", 'arg4' ]

//Mix
sshCommand = `ssh arg1 arg2 'a "  "b \\'\\' c' arg4`;
output = sshCommand.match(/('(\\'|[^'])*'|"(\\"|[^"])*"|\/(\\\/|[^\/])*\/|(\\ |[^ ])+|[\w-]+)/g);
console.log(output); // [ 'ssh', 'arg1', 'arg2', `'a "  "b \\'\\' c'`, 'arg4' ]
```

### 👍 User Acceptance Testing (UAT)

App seems to be working fine.